### PR TITLE
Fix the build with INVARIANTS enabled

### DIFF
--- a/utouch.c
+++ b/utouch.c
@@ -319,7 +319,7 @@ utouch_ev_close_11(struct evdev_dev *evdev, void *ev_softc)
 {
 	struct utouch_softc *sc = ev_softc;
 
-	mtx_assert(&sc->mtx, MA_OWNED);
+	mtx_assert(&sc->sc_mtx, MA_OWNED);
 	usbd_transfer_stop(sc->sc_xfer[UTOUCH_INTR_DT]);
 }
 
@@ -328,7 +328,7 @@ utouch_ev_open_11(struct evdev_dev *evdev, void *ev_softc)
 {
 	struct utouch_softc *sc = ev_softc;
 
-        mtx_assert(&sc->mtx, MA_OWNED);
+        mtx_assert(&sc->sc_mtx, MA_OWNED);
 	usbd_transfer_start(sc->sc_xfer[UTOUCH_INTR_DT]);
 
         return (0);

--- a/utouch.c
+++ b/utouch.c
@@ -57,6 +57,12 @@
 #include <dev/evdev/input.h>
 #include <dev/evdev/evdev.h>
 
+static int utouch_debug = 0;
+static SYSCTL_NODE(_hw_usb, OID_AUTO, utouch, CTLFLAG_RW | CTLFLAG_MPSAFE, 0,
+    "USB touch");
+SYSCTL_INT(_hw_usb_utouch, OID_AUTO, debug, CTLFLAG_RWTUN, &utouch_debug, 0,
+    "Debug level");
+
 enum {
 	UTOUCH_INTR_DT,
 	UTOUCH_N_TRANSFER,


### PR DESCRIPTION
utouch_softc's mutex is spelled "sc_mtx" but one wouldn't notice unless
they were trying to build it with LOCAL_MODULES on freebsd/main.

Reported by:	Graham Perrin <grahamperrin@gmail.com>